### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -848,11 +848,11 @@
       }
     },
     "elm-format": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/elm-format/-/elm-format-0.8.4.tgz",
-      "integrity": "sha512-0KurHC4MBUljdA2Sr+yzcoyAVqCku0LuNpvq5B3UIAlCPZ9PnOW2tUhVnQOCvp9RXngwbnsf18dE48tQ+s8r7g==",
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/elm-format/-/elm-format-0.8.7.tgz",
+      "integrity": "sha512-sVzFXfWnb+6rzXK+q3e3Ccgr6/uS5mFbFk1VSmigC+x2XZ28QycAa7lS8owl009ALPhRQk+pZ95Eq5ANjpEZsQ==",
       "requires": {
-        "binwrap": "^0.2.2"
+        "binwrap": "^0.2.3"
       }
     },
     "elm-test": {


### PR DESCRIPTION
Update elm-format from verson 0.8.4 which have transitive CVEs to the latest version 0.8.7